### PR TITLE
Avoid negative text size in P.3.0

### DIFF
--- a/01_P/P_3_0_01/P_3_0_01.pde
+++ b/01_P/P_3_0_01/P_3_0_01.pde
@@ -49,12 +49,12 @@ void draw(){
 
 void mouseMoved(){
   background(255);
-  textSize((mouseX-width/2)*5+1);
+  textSize(abs(mouseX-width/2)*5+1);
   text(letter, width/2, mouseY);
 }
 
 void mouseDragged(){
-  textSize((mouseX-width/2)*5+1);
+  textSize(abs(mouseX-width/2)*5+1);
   text(letter, width/2, mouseY);
 }
 


### PR DESCRIPTION
I wrapped the difference in a call to abs() to avoid ending up with
a negative text size when the mouse is in the left part of the screen.

The behavior of textSize() with negative values in unspecified;
starting the sketch with the mouse in the left part of the canvas,
I observed first a downward letter A, scaled according to the cursor
horizontal position, then flipped in upright position when the mouse
crosses the middle of the canvas; from this point, whenever the cursor
is in the left part of the canvas, the letter's height is fixed to
a small value, which no longer changes according to horizontal position.
